### PR TITLE
Fix erroneous license violation in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 BSD 3-Clause License
 
+Copyright (c) 2023, Team Vendetta
 Copyright (c) 2024, Team Sunset
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Removing the original "Copyright (c) 2023, Team Vendetta" is in violation of the license, the correct way is to add a second "Copyright (c) 2024, Team Sunset" line below the original. This fixes it.